### PR TITLE
Update to be compatible with %IPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - APPS-13390: Updated to use approriate error macros instead of `$$$GeneralError`
 - APPS-13385: Remove orphaned code in include file `%pkg.isc.json.map`
+- #7: Make the library compatible with %IPM v0.9+
 
 ### Fixed
 - APPS-13384: Mapping cannot override a property from `<Call>` to remove it entirely

--- a/preload/cls/pkg/isc/json/lifecycle.cls
+++ b/preload/cls/pkg/isc/json/lifecycle.cls
@@ -1,14 +1,31 @@
 Class pkg.isc.json.lifecycle Extends %ZPM.PackageManager.Developer.Lifecycle.Module
 {
+
+ClassMethod GetClass(tOld, tNew) [ Internal, Private ]
+{
+	Return $Select(##class(%Dictionary.ClassDefinition).%ExistsId(tNew):tNew, 1:tOld)
+}
+
+ClassMethod GetUtilClass() As %String 
+{
+	Return ..GetClass("%ZPM.PackageManager.Developer.Utils", "%IPM.Utils.Module")
+}
+
+ClassMethod GetLifecycleClass() As %String 
+{
+	Return ..GetClass("%ZPM.PackageManager.Developer.Lifecycle.Module", "%IPM.Lifecycle.Module")
+}
+
 ClassMethod RunOnLoad() [ CodeMode = objectgenerator ]
 {
 	Quit:$Extract($Namespace)="^" $$$OK
 	Set sc = $$$OK
 	Try {
-		Set sourceDB = ##class(%ZPM.PackageManager.Developer.Utils).GetRoutineDatabase($Namespace)
-		Set sc = ##class(%ZPM.PackageManager.Developer.Utils).AddGlobalMapping($Namespace,"oddPKG(""%pkg.isc.json"")",sourceDB)
+		set tUtilCls = $Select(##class(%Dictionary.ClassDefinition).%ExistsId("%IPM.Utils.Module"):"%IPM.Utils.Module", 1:"%ZPM.PackageManager.Developer.Utils")
+		Set sourceDB = $ClassMethod(tUtilCls, "GetRoutineDatabase",$Namespace)
+		Set sc = $ClassMethod(tUtilCls, "AddGlobalMapping", $Namespace, "oddPKG(""%pkg.isc.json"")", sourceDB)
 		$$$ThrowOnError(sc)
-		Set sc = ##class(%ZPM.PackageManager.Developer.Utils).AddPackageMapping($Namespace,"%pkg.isc.json",sourceDB)
+		Set sc = $ClassMethod(tUtilCls, "AddPackageMapping", $Namespace, "%pkg.isc.json", sourceDB)
 		$$$ThrowOnError(sc)
 	} Catch e {
 		Set sc = e.AsStatus()
@@ -20,14 +37,14 @@ Method %Reload(ByRef pParams) As %Status
 {
 	Set sc = $$$OK
 	Try {
-		Set sourceDB = ##class(%ZPM.PackageManager.Developer.Utils).GetRoutineDatabase($Namespace)
-		Set sc = ##class(%ZPM.PackageManager.Developer.Utils).AddGlobalMapping($Namespace,"oddPKG(""%pkg.isc.json"")",sourceDB)
+		Set sourceDB = $ClassMethod(..GetUtilClass(), "GetRoutineDatabase", $Namespace)
+		Set sc = $ClassMethod(..GetUtilClass(), "AddGlobalMapping", $Namespace, "oddPKG(""%pkg.isc.json"")", sourceDB)
 		$$$ThrowOnError(sc)
-		Set sc = ##class(%ZPM.PackageManager.Developer.Utils).AddPackageMapping($Namespace,"%pkg.isc.json",sourceDB)
+		Set sc = $ClassMethod(..GetUtilClass(), "AddPackageMapping", $Namespace, "%pkg.isc.json", sourceDB)
 		$$$ThrowOnError(sc)
 		// Ensure super is called AFTER mappings are set up
 		Set sc = ##super(.pParams)
-		$$$ThrowOnError(sc)
+		$$$ThrowOnError(sc) 
 	} Catch e {
 		Set sc = e.AsStatus()
 	}
@@ -40,8 +57,8 @@ Method %Clean(ByRef pParams) As %Status
 	Try {
 		Set sc = ##super(.pParams)
 		$$$ThrowOnError(sc)
-		Do ##class(%ZPM.PackageManager.Developer.Utils).RemoveGlobalMapping($Namespace,"oddPKG(""%pkg.isc.json"")")
-		Do ##class(%ZPM.PackageManager.Developer.Utils).RemovePackageMapping($Namespace,"%pkg.isc.json")
+		Do $ClassMethod(..GetUtilClass(), "RemoveGlobalMapping", $Namespace, "oddPKG(""%pkg.isc.json"")")
+		Do $ClassMethod(..GetUtilClass(), "RemovePackageMapping", $Namespace, "%pkg.isc.json")
 	} Catch e {
 		Set sc = e.AsStatus()
 	}


### PR DESCRIPTION
Make the library compatible with %IPM 0.9.
The parent class for preload lifecycle class will be automatically updated once https://github.com/intersystems/ipm/pull/513 is merged